### PR TITLE
chore: Add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      open-pull-requests-limit: 1
+      labels:
+        - tag:bot
+        - type:github-actions


### PR DESCRIPTION
This pull request introduces a configuration file for Dependabot to automate dependency updates for GitHub Actions.

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R10): Added a configuration file to set up Dependabot for GitHub Actions with daily updates, a limit of one open pull request, and labels `tag:bot` and `type:github-actions`.